### PR TITLE
use Rails.env instead of ENV[‘RAILS_ENV’]

### DIFF
--- a/lib/thoth/rails/railtie.rb
+++ b/lib/thoth/rails/railtie.rb
@@ -5,7 +5,7 @@ module Thoth
   class Railtie < ::Rails::Railtie
     initializer "thoth.configure_rails_initialization" do
       Thoth.logger ||= (
-        file = File.open(::Rails.root.join(*%W[log events_#{ENV['RAILS_ENV']}.log]), 'a')
+        file = File.open(::Rails.root.join(*%W[log events_#{::Rails.env}.log]), 'a')
         file.sync = true
         Logger.new(Output::Json.new(file))
       )


### PR DESCRIPTION
noticed my logs were getting saved as "events_.log" from unicorn workers since by default unicorn only sets this var in the master process and not the children.  I think Rails.env is more correct here.